### PR TITLE
Fix TestBalatroMCPAsyncFileTransportConfiguration base_path assertion

### DIFF
--- a/tests/test_balatromcp_transport_initialization_luaunit.lua
+++ b/tests/test_balatromcp_transport_initialization_luaunit.lua
@@ -64,6 +64,7 @@ local function setUp()
     _G.FileTransport = {
         new = function(base_path)
             return {
+                base_path = base_path or "shared",  -- Store the base_path parameter
                 is_available = function() return true end,
                 write_message = function(self, data, type) return true end,
                 read_message = function(self, type) return nil end,


### PR DESCRIPTION
## Summary
- Fixed the base_path assertion issue in TestBalatroMCPAsyncFileTransportConfiguration
- Updated the FileTransport mock to properly store the base_path parameter
- Test now passes consistently

## Problem
The test was failing because the mock FileTransport.new() function wasn't storing the base_path parameter that was passed to it, causing `mcp.transport.base_path` to return nil instead of the expected "custom_shared" value.

## Solution
Updated the mock FileTransport constructor to store the base_path parameter as a property of the returned transport object, matching the behavior of the real FileTransport class.

## Test Results
- Before: TestBalatroMCPAsyncFileTransportConfiguration FAILED
- After: TestBalatroMCPAsyncFileTransportConfiguration PASSED
- Overall test suite: +1 success (198 successes vs 197 before)

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)