### PR TITLE
Fix MessageManager timestamp formatting issue

### DIFF
--- a/tests/test_crash_diagnostics_luaunit.lua
+++ b/tests/test_crash_diagnostics_luaunit.lua
@@ -55,7 +55,14 @@ local function setup_test_environment()
     -- Safely preserve original os functions before mocking
     local original_os = _G.os
     _G.os = setmetatable({
-        date = function(format) return "12:34:56" end,
+        date = function(format) 
+            -- Check if this is an ISO 8601 format request
+            if format and string.find(format, "%%Y.*%%m.*%%d.*T.*%%H.*%%M.*%%S.*Z") then
+                return "2025-06-27T12:34:56Z"
+            else
+                return "12:34:56"
+            end
+        end,
         time = function() return 1234567890 end,
         clock = original_os and original_os.clock or function() return 1234567890 end
     }, {


### PR DESCRIPTION
## Summary
- Fixed os.date mock in crash diagnostics test to support ISO 8601 format
- The mock was always returning "12:34:56" regardless of format parameter
- Updated to detect ISO format requests and return proper timestamps with T and Z separators

## Test plan
- [x] Run test suite to verify MessageManager timestamp test now passes
- [x] Confirmed test suite now shows 198 successes vs previous 197 (one additional passing test)
- [x] No regression in other crash diagnostics functionality

🤖 Generated with [Claude Code](https://claude.ai/code)