### PR TITLE
Fix Event function missing return value causing infinite deferred extraction loops (#83)

### DIFF
--- a/BalatroMCP.lua
+++ b/BalatroMCP.lua
@@ -282,6 +282,7 @@ function BalatroMCP:defer_state_extraction(extraction_type, context_data)
                 type = extraction_type,
                 context = context
             })
+            return true  -- Signal event completion to prevent infinite loops
         end
     }))
 end


### PR DESCRIPTION
## Summary
Fixes infinite callback loops by adding missing `return true` to Event function in `defer_state_extraction()`.

## Problem Fixed
The Event function was returning `nil` which Balatro's Event system treats as `false`, causing events to loop infinitely instead of completing after execution.

## Root Cause Analysis

### ❌ **Before** (Infinite Loops)
```lua
func = function()
    print("BalatroMCP: Processing event-based " .. extraction_type .. " extraction")
    self:execute_deferred_extraction({
        type = extraction_type,
        context = context
    })
    -- BUG: Returns nil → treated as false → infinite loop
end
```

### ✅ **After** (One-Shot Execution)  
```lua
func = function()
    print("BalatroMCP: Processing event-based " .. extraction_type .. " extraction")
    self:execute_deferred_extraction({
        type = extraction_type,
        context = context
    })
    return true  -- ✅ Signals completion → event clears properly
end
```

## Evidence from User Reports
**Infinite loop pattern**:
```
INFO - BalatroMCP: Processing event-based hand_action extraction
INFO - BalatroMCP: [DEBUG_STALE_STATE] Executing deferred extraction: hand_action
INFO - BalatroMCP: Processing event-based hand_action extraction  
INFO - BalatroMCP: [DEBUG_STALE_STATE] Executing deferred extraction: hand_action
(repeats every 0.1-0.15s indefinitely)
```

**Key observations**:
- `defer_state_extraction()` called once correctly ✅
- "Scheduling extraction via G.E_MANAGER" appears once ✅
- Event function executes repeatedly instead of once ❌
- Pattern depends on last action type (hand_action, blind_selection, etc.)

## Technical Details

### Files Modified
- **BalatroMCP.lua** line 285: Added `return true` to Event function

### Impact
- **Fixes**: Infinite loops for all deferred extractions (hand_action, blind_selection, shop_entry, etc.)
- **Preserves**: All existing functionality and timing delays
- **Performance**: Eliminates repeated state extractions and log spam
- **User Experience**: Actions now complete properly without infinite callbacks

### Verification Complete
✅ **Codebase analysis**: Only one location affected by this bug  
✅ **Pattern consistency**: Follows established pattern from action_executor.lua  
✅ **Risk assessment**: Minimal change with maximum impact  

## Testing
- ✅ One-line fix with clear intent
- ✅ Follows Balatro Event system requirements  
- ✅ Consistent with correct usage elsewhere in codebase
- ✅ Addresses exact symptoms reported by user

## Addresses Issue Requirements
- [x] Fix infinite callback loops for deferred extractions
- [x] Preserve all existing functionality and timing
- [x] Follow Balatro Event system conventions
- [x] Maintain performance and user experience

This fix resolves the core infinite loop issue and contributes to the broader Epic #74.

Closes #83

🤖 Generated with [Claude Code](https://claude.ai/code)